### PR TITLE
docs(site): introduce color scheme toggle

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,6 +19,11 @@
     <link rel="stylesheet" href="https://unpkg.com/range-slider-element@next/dist/range-slider-element.css">
   </head>
   <body>
+    <header>
+      <button data-color-scheme-toggle aria-label="Toggle color scheme">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" role="img"><path d="M12 8a2.83 2.83 0 0 0 4 4 4 4 0 1 1-4-4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.9 4.9 1.4 1.4"/><path d="m17.7 17.7 1.4 1.4"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.3 17.7-1.4 1.4"/><path d="m19.1 4.9-1.4 1.4"/></svg>
+      </button>
+    </header>
     <main>
       <section data-section="intro">
         <span class="emoji" aria-hidden="true">🎚</span>
@@ -264,6 +269,38 @@ range-slider [data-runnable-track] {}</syntax-highlight>
           button.textContent = defaultContent;
         }, 1800);
       })
+    </script>
+
+    <script type="module">
+      const systemPreference = getSystemColorScheme();
+
+      document.addEventListener('click', (event) => {
+        const target = event.target.closest('[data-color-scheme-toggle]');
+        if (!target) return;
+        toggleColorScheme();
+      });
+
+      function toggleColorScheme() {
+        const currentPreference = getColorScheme();
+        const newPreference = currentPreference === 'dark' ? 'light' : 'dark';
+        setColorScheme(newPreference);
+      }
+
+      function getColorScheme() {
+        const computedStyle = window.getComputedStyle(document.documentElement);
+        const currentPreference = computedStyle.getPropertyValue('color-scheme');
+        const isSystem = currentPreference === 'light dark';
+        return isSystem ? systemPreference : currentPreference;
+      }
+
+      function setColorScheme(newPreference) {
+        document.documentElement.style.setProperty('color-scheme', newPreference);
+      }
+
+      function getSystemColorScheme() {
+        if (window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
+        return 'light';
+      }
     </script>
   </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -86,6 +86,24 @@
     border-color: light-dark(var(--light-accent), var(--dark-accent));
   }
 
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    background-color: light-dark(
+      var(--light-button-face-muted),
+      var(--dark-button-face-muted)
+    );
+    border-block-end: 1px solid
+      light-dark(var(--light-button-face), var(--dark-button-face));
+    padding: var(--spacing-2) var(--spacing-4);
+
+    [data-color-scheme-toggle] {
+      padding: var(--spacing-2);
+      aspect-ratio: 1;
+    }
+  }
+
   main {
     display: flex;
     flex-direction: column;
@@ -98,7 +116,12 @@
   }
 
   footer {
-    border-block-start: 1px solid light-dark(#e2e2e3, #000000);
+    background-color: light-dark(
+      var(--light-button-face-muted),
+      var(--dark-button-face-muted)
+    );
+    border-block-start: 1px solid
+      light-dark(var(--light-button-face), var(--dark-button-face));
     text-align: center;
     margin-inline: auto;
     margin-block-start: auto;
@@ -171,9 +194,6 @@
       gap: .5rem;
       font-size: 0;
       padding-block-start: var(--spacing-6);
-    }
-
-    .badges img {
       filter: drop-shadow(0.35rem 0.35rem 0.4rem rgba(0, 0, 0, 0.5));
     }
 
@@ -234,7 +254,10 @@
       align-self: stretch;
       gap: 1rem;
       min-block-size: 300px;
-      background-color: light-dark(#fdfdfd, #212121);
+      background-color: light-dark(
+        var(--light-button-face-muted),
+        var(--dark-button-face-muted)
+      );
       border: 1px solid
         light-dark(var(--light-button-face), var(--dark-button-face));
       border-radius: 1rem;
@@ -367,6 +390,7 @@
     --dark-canvas-text: rgba(255, 255, 255, 0.871);
     --dark-link-text: var(--dark-accent);
     --dark-button-face: #1a1a1a;
+    --dark-button-face-muted: #212121;
 
     /* #6261ff */
     --light-accent: #4a46e0;
@@ -374,6 +398,7 @@
     --light-canvas-text: #414141;
     --light-link-text: var(--light-accent);
     --light-button-face: #f9f9f9;
+    --light-button-face-muted: #fdfdfd;
   }
 }
 


### PR DESCRIPTION
## What changed (additional context)

Introduce a color scheme toggle to the docs site.

## Proof of work (screenshots / screen recordings)


https://github.com/user-attachments/assets/a1802991-8375-4aa0-ae41-1ffb25ab3b1e

