### PR TITLE
fix: "input" and "change" events

### DIFF
--- a/src/range-slider-element.js
+++ b/src/range-slider-element.js
@@ -22,6 +22,7 @@ export default class RangeSliderElement extends HTMLElement {
   static formAssociated = true;
 
   #internals;
+  #startValue;
   #value = [];
   #valuePercent = [];
   #thumbIndex = 0;
@@ -203,6 +204,9 @@ export default class RangeSliderElement extends HTMLElement {
     window.addEventListener('pointerup', this.#endHandler);
     window.addEventListener('pointercancel', this.#endHandler);
 
+    // Update value change reference
+    this.#startValue = this.value;
+
     // Thumb click
     if (event.target.dataset.thumb !== undefined) {
       this.#thumbIndex = Number(event.target.dataset.thumb);
@@ -227,8 +231,10 @@ export default class RangeSliderElement extends HTMLElement {
     window.removeEventListener('pointerup', this.#endHandler);
     window.removeEventListener('pointercancel', this.#endHandler);
 
-    // TODO: check if value changed
-    this.dispatchEvent(new Event('change', { bubbles: true }));
+    // Trigger change event
+    if (this.#startValue !== this.value) {
+      this.dispatchEvent(new Event('change', { bubbles: true }));
+    }
   };
 
   #keyboardHandler = (event) => {

--- a/src/range-slider-element.js
+++ b/src/range-slider-element.js
@@ -253,7 +253,7 @@ export default class RangeSliderElement extends HTMLElement {
     const safeOffset = Math.min(Math.max(offset, 0), this.#size);
     const percent = safeOffset / this.#size;
     const computedValue = this.#getValueFromPercent(this.#isRTL ? 1 - percent : percent);
-    this.#updateValue(this.#thumbIndex, computedValue);
+    this.#updateValue(this.#thumbIndex, computedValue, ['input']);
   };
 
   #getDefaultValue() {
@@ -321,9 +321,9 @@ export default class RangeSliderElement extends HTMLElement {
    *
    * @param {number} index
    * @param {number} value
-   * @param {Array} dispatchEvents
+   * @param {string[]} dispatchEvents
    */
-  #updateValue(index, value, dispatchEvents = ['input']) {
+  #updateValue(index, value, dispatchEvents = []) {
     const oldValue = this.#value[index];
     const valuePrecision = Number(this.valuePrecision) || getPrescision(this.step) || 0;
     const thumbMinValue = this.#value[index - 1] || this.min;


### PR DESCRIPTION
## What changed (additional context)

- Do not send "input" event for initial value.
  In addition, programmatic value changes do not send the "input" event. This matches the default browser behavior.
-  Send "change" event only if value has changed
- Test "input" & "change" events