### PR TITLE
feat: allow opt-out of define()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 import './style.css';
 import RangeSliderElement from './range-slider-element';
+
 export { RangeSliderElement as default };
 
-if (!window.customElements.get(RangeSliderElement.tagName)) {
-  window.RangeSliderElement = RangeSliderElement;
-  window.customElements.define(RangeSliderElement.tagName, RangeSliderElement);
+if (!new URL(import.meta.url).searchParams.has('define', 'false')) {
+  window.RangeSliderElement = RangeSliderElement.define();
 }

--- a/src/range-slider-element.js
+++ b/src/range-slider-element.js
@@ -17,7 +17,13 @@ TEMPLATE.innerHTML = `
 `;
 
 export default class RangeSliderElement extends HTMLElement {
-  static tagName = 'range-slider';
+  static define(tagName = 'range-slider', registry = customElements) {
+    if (!registry.get(tagName)) {
+      registry.define(tagName, RangeSliderElement);
+      return RangeSliderElement;
+    }
+  }
+
   static observedAttributes = REFLECTED_ATTRIBUTES;
   static formAssociated = true;
 


### PR DESCRIPTION
## What changed (additional context)

Introduce option to opt-out of `define()` by adding a `?define=false` query parameter to the import/script URL.

- Allows the use of a different tag name
- Run some additional configuration before definition etc.

```html
<script type="module">
  // <range-slider> is not automatically defined
  import "range-slider-element?define=false";

  // ...

  RangeSliderElement.define("different-tag-name");
</script>
```