### PR TITLE
chore(deps-dev): bump vitest from 3.2.2 to 3.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
-        "@vitest/browser": "3.2.2",
+        "@vitest/browser": "3.2.3",
         "conventional-changelog-cli": "5.0.0",
         "playwright": "1.52.0",
         "typescript": "5.8.3",
         "vite": "6.3.5",
-        "vitest": "3.2.2"
+        "vitest": "3.2.3"
       },
       "funding": {
         "url": "https://github.com/andreruffert/range-slider-element?sponsor=1"
@@ -1044,16 +1044,16 @@
       "license": "MIT"
     },
     "node_modules/@vitest/browser": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.2.2.tgz",
-      "integrity": "sha512-LJk8ZhCGhgG6G6jFFJ9LX83ibRY8FszLuu9zPaYFDrcHbBwNXwt1v06HRs/vHVYxwjw3/BGzSIgn9Et2P6rCiA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.2.3.tgz",
+      "integrity": "sha512-5HpUb0ixGF8JWSAjb/P1x/VPuTYUkL4pL0+YO6DJiuvQgqJN3PREaUEcXwfXjU4nBc37EahfpRbAwdE9pHs9lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
-        "@vitest/mocker": "3.2.2",
-        "@vitest/utils": "3.2.2",
+        "@vitest/mocker": "3.2.3",
+        "@vitest/utils": "3.2.3",
         "magic-string": "^0.30.17",
         "sirv": "^3.0.1",
         "tinyrainbow": "^2.0.0",
@@ -1064,7 +1064,7 @@
       },
       "peerDependencies": {
         "playwright": "*",
-        "vitest": "3.2.2",
+        "vitest": "3.2.3",
         "webdriverio": "^7.0.0 || ^8.0.0 || ^9.0.0"
       },
       "peerDependenciesMeta": {
@@ -1080,15 +1080,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.2.tgz",
-      "integrity": "sha512-ipHw0z669vEMjzz3xQE8nJX1s0rQIb7oEl4jjl35qWTwm/KIHERIg/p/zORrjAaZKXfsv7IybcNGHwhOOAPMwQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.3.tgz",
+      "integrity": "sha512-W2RH2TPWVHA1o7UmaFKISPvdicFJH+mjykctJFoAkUw+SPTJTGjUNdKscFBrqM7IPnCVu6zihtKYa7TkZS1dkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.2",
-        "@vitest/utils": "3.2.2",
+        "@vitest/spy": "3.2.3",
+        "@vitest/utils": "3.2.3",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1097,13 +1097,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.2.tgz",
-      "integrity": "sha512-jKojcaRyIYpDEf+s7/dD3LJt53c0dPfp5zCPXz9H/kcGrSlovU/t1yEaNzM9oFME3dcd4ULwRI/x0Po1Zf+LTw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.3.tgz",
+      "integrity": "sha512-cP6fIun+Zx8he4rbWvi+Oya6goKQDZK+Yq4hhlggwQBbrlOQ4qtZ+G4nxB6ZnzI9lyIb+JnvyiJnPC2AGbKSPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.2",
+        "@vitest/spy": "3.2.3",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1124,9 +1124,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.2.tgz",
-      "integrity": "sha512-FY4o4U1UDhO9KMd2Wee5vumwcaHw7Vg4V7yR4Oq6uK34nhEJOmdRYrk3ClburPRUA09lXD/oXWZ8y/Sdma0aUQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.3.tgz",
+      "integrity": "sha512-yFglXGkr9hW/yEXngO+IKMhP0jxyFw2/qys/CK4fFUZnSltD+MU7dVYGrH8rvPcK/O6feXQA+EU33gjaBBbAng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1137,27 +1137,28 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.2.tgz",
-      "integrity": "sha512-GYcHcaS3ejGRZYed2GAkvsjBeXIEerDKdX3orQrBJqLRiea4NSS9qvn9Nxmuy1IwIB+EjFOaxXnX79l8HFaBwg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.3.tgz",
+      "integrity": "sha512-83HWYisT3IpMaU9LN+VN+/nLHVBCSIUKJzGxC5RWUOsK1h3USg7ojL+UXQR3b4o4UBIWCYdD2fxuzM7PQQ1u8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.2",
-        "pathe": "^2.0.3"
+        "@vitest/utils": "3.2.3",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.2.tgz",
-      "integrity": "sha512-aMEI2XFlR1aNECbBs5C5IZopfi5Lb8QJZGGpzS8ZUHML5La5wCbrbhLOVSME68qwpT05ROEEOAZPRXFpxZV2wA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.3.tgz",
+      "integrity": "sha512-9gIVWx2+tysDqUmmM1L0hwadyumqssOL1r8KJipwLx5JVYyxvVRfxvMq7DaWbZZsCqZnu/dZedaZQh4iYTtneA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.2",
+        "@vitest/pretty-format": "3.2.3",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1166,9 +1167,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.2.tgz",
-      "integrity": "sha512-6Utxlx3o7pcTxvp0u8kUiXtRFScMrUg28KjB3R2hon7w4YqOFAEA9QwzPVVS1QNL3smo4xRNOpNZClRVfpMcYg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.3.tgz",
+      "integrity": "sha512-JHu9Wl+7bf6FEejTCREy+DmgWe+rQKbK+y32C/k5f4TBIAlijhJbRBIRIOCEpVevgRsCQR2iHRUH2/qKVM/plw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1179,13 +1180,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.2.tgz",
-      "integrity": "sha512-qJYMllrWpF/OYfWHP32T31QCaLa3BAzT/n/8mNGhPdVcjY+JYazQFO1nsJvXU12Kp1xMpNY4AGuljPTNjQve6A==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.3.tgz",
+      "integrity": "sha512-4zFBCU5Pf+4Z6v+rwnZ1HU1yzOKKvDkMXZrymE2PBlbjKJRlrOxbvpfPSvJTGRIwGoahaOGvp+kbCoxifhzJ1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.2",
+        "@vitest/pretty-format": "3.2.3",
         "loupe": "^3.1.3",
         "tinyrainbow": "^2.0.0"
       },
@@ -1835,9 +1836,9 @@
       "license": "MIT"
     },
     "node_modules/loupe": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
-      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
+      "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2289,6 +2290,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2360,9 +2381,9 @@
       }
     },
     "node_modules/tinypool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
-      "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2540,9 +2561,9 @@
       }
     },
     "node_modules/vite-node": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.2.tgz",
-      "integrity": "sha512-Xj/jovjZvDXOq2FgLXu8NsY4uHUMWtzVmMC2LkCu9HWdr9Qu1Is5sanX3Z4jOFKdohfaWDnEJWp9pRP0vVpAcA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.3.tgz",
+      "integrity": "sha512-gc8aAifGuDIpZHrPjuHyP4dpQmYXqWw7D1GmDnWeNWP654UEXzVfQ5IHPSK5HaHkwB/+p1atpYpSdw/2kOv8iQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2578,20 +2599,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.2.tgz",
-      "integrity": "sha512-fyNn/Rp016Bt5qvY0OQvIUCwW2vnaEBLxP42PmKbNIoasSYjML+8xyeADOPvBe+Xfl/ubIw4og7Lt9jflRsCNw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.3.tgz",
+      "integrity": "sha512-E6U2ZFXe3N/t4f5BwUaVCKRLHqUpk1CBWeMh78UT4VaTPH/2dyvH6ALl29JTovEPu9dVKr/K/J4PkXgrMbw4Ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.2",
-        "@vitest/mocker": "3.2.2",
-        "@vitest/pretty-format": "^3.2.2",
-        "@vitest/runner": "3.2.2",
-        "@vitest/snapshot": "3.2.2",
-        "@vitest/spy": "3.2.2",
-        "@vitest/utils": "3.2.2",
+        "@vitest/expect": "3.2.3",
+        "@vitest/mocker": "3.2.3",
+        "@vitest/pretty-format": "^3.2.3",
+        "@vitest/runner": "3.2.3",
+        "@vitest/snapshot": "3.2.3",
+        "@vitest/spy": "3.2.3",
+        "@vitest/utils": "3.2.3",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -2605,7 +2626,7 @@
         "tinypool": "^1.1.0",
         "tinyrainbow": "^2.0.0",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.2",
+        "vite-node": "3.2.3",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -2621,8 +2642,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.2",
-        "@vitest/ui": "3.2.2",
+        "@vitest/browser": "3.2.3",
+        "@vitest/ui": "3.2.3",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
-    "@vitest/browser": "3.2.2",
+    "@vitest/browser": "3.2.3",
     "conventional-changelog-cli": "5.0.0",
     "playwright": "1.52.0",
     "typescript": "5.8.3",
     "vite": "6.3.5",
-    "vitest": "3.2.2"
+    "vitest": "3.2.3"
   },
   "volta": {
     "node": "22.13.1",


### PR DESCRIPTION
## What changed (additional context)

Bumps [vitest](https://github.com/vitest-dev/vitest/tree/HEAD/packages/vitest) from 3.2.2 to 3.2.3.
Bumps [@vitest/browser](https://github.com/vitest-dev/vitest/tree/HEAD/packages/browser) from 3.2.2 to 3.2.3.

Related: closes #175, closes #176

