### PR TITLE
feat: introduce `min-steps-between-thumbs` attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
         margin-block: 1em;
         text-align: center;
         user-select: none;
+        font-variant-numeric: tabular-nums;
       }
 
       /* Debug styles */
@@ -224,12 +225,23 @@
           </div>
         </range-slider>
 
+        <p><code>orientation="vertical"</code></p>
         <range-slider value="10,80" orientation="vertical">
           <div data-track></div>
           <div data-track-fill></div>
           <div data-runnable-track>
             <div data-thumb></div>
             <div data-thumb></div>
+          </div>
+        </range-slider>
+
+        <p><code>min-steps-between-thumbs</code></p>
+        <range-slider value="10,40" step="1" min-steps-between-thumbs="1" name="price-range">
+          <div data-track></div>
+          <div data-track-fill></div>
+          <div data-runnable-track>
+            <div data-thumb aria-label="Minimum Price"></div>
+            <div data-thumb aria-label="Maximum Price"></div>
           </div>
         </range-slider>
       </section>

--- a/src/range-slider-element.js
+++ b/src/range-slider-element.js
@@ -89,6 +89,14 @@ export class RangeSliderElement extends HTMLElement {
   get valuePrecision() {
     return this.getAttribute('value-precision') || '';
   }
+  /**
+   * @returns {number}
+   */
+  get minStepsBetweenThumbs() {
+    return this.hasAttribute('min-steps-between-thumbs')
+      ? Number(this.getAttribute('min-steps-between-thumbs'))
+      : 0;
+  }
   get #isVertical() {
     return Boolean(this.getAttribute('orientation') === 'vertical');
   }
@@ -147,6 +155,12 @@ export class RangeSliderElement extends HTMLElement {
   }
   set valuePrecision(precision) {
     this.setAttribute('value-precision', precision);
+  }
+  /**
+   * @param {number} steps
+   */
+  set minStepsBetweenThumbs(steps) {
+    this.setAttribute('min-steps-between-thumbs', steps);
   }
 
   /**
@@ -366,8 +380,21 @@ export class RangeSliderElement extends HTMLElement {
   #updateValue(index, value, dispatchEvents = []) {
     const oldValue = this.#value[index];
     const valuePrecision = Number(this.valuePrecision) || getPrescision(this.step) || 0;
-    const thumbMinValue = this.#value[index - 1] || this.min;
-    const thumbMaxValue = this.#value[index + 1] || this.max;
+
+    let thumbMinValue = this.#value[index - 1] || this.min;
+    let thumbMaxValue = this.#value[index + 1] || this.max;
+
+    // Avoid thumbs with equal values
+    if (this.#isMultiThumb && this.minStepsBetweenThumbs) {
+      // Skip first thumb
+      if (index > 0) {
+        thumbMinValue = thumbMinValue + this.minStepsBetweenThumbs * this.step;
+      }
+      // Skip last thumb
+      if (index < this.#thumbs.length - 1) {
+        thumbMaxValue = thumbMaxValue - this.minStepsBetweenThumbs * this.step;
+      }
+    }
 
     // Thumb min, max constrain
     const safeValue = Math.min(Math.max(value, thumbMinValue), thumbMaxValue);


### PR DESCRIPTION
## What changed (additional context)

Useful for multi thumb sliders. Avoid thumbs with equal values.

- [x] Feature implementation
- [ ] Tests

Related: https://github.com/andreruffert/range-slider-element/discussions/178

## Proof of work (screenshots / screen recordings)



https://github.com/user-attachments/assets/b02dd2c1-adad-4faf-8fdc-4fe885d84895

