### PR TITLE
fix: HTML5 compliant step rounding to use min as step base

### DIFF
--- a/src/range-slider-element.js
+++ b/src/range-slider-element.js
@@ -373,7 +373,9 @@ export class RangeSliderElement extends HTMLElement {
     const safeValue = Math.min(Math.max(value, thumbMinValue), thumbMaxValue);
 
     // Rounding in steps
-    const nearestValue = Math.round(safeValue / this.step) * this.step;
+    const offset = safeValue - this.min;
+    const nearestOffset = Math.round(offset / this.step) * this.step;
+    const nearestValue = this.min + nearestOffset;
 
     // Value precision
     const newValue = Number(


### PR DESCRIPTION
## What changed (additional context)

Fixed a bug in the range slider step behaviour where values were being rounded relative to 0 instead of using the `min` attribute as the step base, compliant with HTML5 specification.

Related:
- HTML5 Step Attribute Specification: https://html.spec.whatwg.org/multipage/input.html#the-step-attribute
- Step Base Algorithm: https://html.spec.whatwg.org/multipage/input.html#concept-input-min-zero

## Proof of work (screenshots / screen recordings)

<!-- Please provide before/after screenshots for any visual changes -->

Range slider with `min=5, step=2` - values snap to even numbers (6, 8, 10...) instead of odd numbers (5, 7, 9...).

| before | after |
| ------ | ----- |
| Values snap to: 6, 8, 10, 12, 14... | Values snap to: 5, 7, 9, 11, 13... |
| Incorrect rounding from 0 | Correct rounding from min |
| HTML5 non-compliant | HTML5 compliant |

This was discovered whilst porting rangslider.js to the range-slider-element component in Drupal, see https://www.drupal.org/project/range_slider/issues/3547819
